### PR TITLE
[lugbot] Upgrade workspace plugin version to 3.0.7

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.workspace", version: "3.0.6"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.workspace", version: "3.0.7"
 		classpath group: "net.saliman", name: "gradle-properties-plugin", version: "1.4.6"
 	}
 


### PR DESCRIPTION
### lugbot has created this PR to upgrade workspace plugin version to latest.
![merge advice](https://img.shields.io/badge/merge%20advice-recommended-orange)

Upgrade workspace plugin version to 3.0.7

---

:information_source: The upgrades provided in this PR will not be tried again until the branch upgrade is deleted.